### PR TITLE
dont silently rescue accessor for property_key we need to paginate by

### DIFF
--- a/lib/ar-find-in-batches-with-order.rb
+++ b/lib/ar-find-in-batches-with-order.rb
@@ -28,12 +28,12 @@ module ActiveRecord
 
         break if records_size < batch_size
 
-        next_start = records.last.try(property_key)
+        next_start = records.last.send(property_key)
         with_start_ids.clear if start != next_start
         start = next_start
 
         records.each do |record|
-          if record.try(property_key) == start
+          if record.send(property_key) == start
             with_start_ids << record.id
           end
         end

--- a/lib/ar-find-in-batches-with-order.rb
+++ b/lib/ar-find-in-batches-with-order.rb
@@ -7,7 +7,7 @@ module ActiveRecord
 
       # we have to be explicit about the options to ensure proper ordering and retrieval
 
-      direction = options.delete(:direction) || (arel.orders.first.try(:ascending?) ? :asc : nil) || (arel.orders.first.try(:descending?) ? :desc : nil) || :desc
+      direction = options.delete(:direction) || (arel.orders.first.try(:ascending?) ? :asc : nil) || (arel.orders.first.try(:descending?) ? :desc : nil) || raise "please pass :direction that matches sort order"
       start = options.delete(:start)
       collate = options[:collate] ? "COLLATE #{connection.quote_column_name(options[:collate])}" : ""
       batch_size = options.delete(:batch_size) || 1000

--- a/lib/ar-find-in-batches-with-order.rb
+++ b/lib/ar-find-in-batches-with-order.rb
@@ -7,7 +7,7 @@ module ActiveRecord
 
       # we have to be explicit about the options to ensure proper ordering and retrieval
 
-      direction = options.delete(:direction) || (arel.orders.first.try(:ascending?) ? :asc : nil) || (arel.orders.first.try(:descending?) ? :desc : nil) || raise "please pass :direction that matches sort order"
+      direction = options.delete(:direction) || (arel.orders.first.try(:ascending?) ? :asc : nil) || (arel.orders.first.try(:descending?) ? :desc : nil) || raise("please pass :direction that matches sort order")
       start = options.delete(:start)
       collate = options[:collate] ? "COLLATE #{connection.quote_column_name(options[:collate])}" : ""
       batch_size = options.delete(:batch_size) || 1000

--- a/lib/ar-find-in-batches-with-order.rb
+++ b/lib/ar-find-in-batches-with-order.rb
@@ -9,6 +9,7 @@ module ActiveRecord
 
       direction = options.delete(:direction) || (arel.orders.first.try(:ascending?) ? :asc : nil) || (arel.orders.first.try(:descending?) ? :desc : nil) || :desc
       start = options.delete(:start)
+      collate = options[:collate] ? "COLLATE #{connection.quote_column_name(options[:collate])}" : ""
       batch_size = options.delete(:batch_size) || 1000
       with_start_ids = []
 
@@ -39,7 +40,7 @@ module ActiveRecord
         end
 
         without_dups = relation.where.not(relation.klass.primary_key => with_start_ids)
-        records = (direction == :desc ? without_dups.where("#{sanitized_key} <= ?", start).to_a : without_dups.where("#{sanitized_key} >= ?", start).to_a)
+        records = (direction == :desc ? without_dups.where("#{sanitized_key} <= ? #{collate}", start).to_a : without_dups.where("#{sanitized_key} >= ? #{collate}", start).to_a)
       end
     end
 


### PR DESCRIPTION
I presume it was initially there to handle nil, but it's not possible for the record to be nil.  try also rescues errors like ActiveModel::MissingAttributeError if you haven't happened to select the property_key (or just give a totally invalid one), resulting in pagination silently failing and just returning the first batch.  